### PR TITLE
Override default selection background for active match

### DIFF
--- a/style/search.css
+++ b/style/search.css
@@ -1,6 +1,6 @@
 .ProseMirror-search-match {
   background-color: #ffff0054;
 }
-.ProseMirror-active-search-match {
+.ProseMirror-active-search-match::selection {
   background-color: #ff6a0054;
 }

--- a/style/search.css
+++ b/style/search.css
@@ -1,6 +1,9 @@
 .ProseMirror-search-match {
   background-color: #ffff0054;
 }
-.ProseMirror-active-search-match::selection {
+.ProseMirror.ProseMirror-focused .ProseMirror-active-search-match::selection {
+  background-color: #ff6a0054;
+}
+.ProseMirror:not(.ProseMirror-focused) .ProseMirror-active-search-match {
   background-color: #ff6a0054;
 }


### PR DESCRIPTION
When the editor is focused and `.ProseMirror-active-search-match` exists, the selection background color (usually in light blue) and the orange active decoration will overlap. This PR fixes the issue by only applying background color to `::selection`. 

A tiny issue is that, in Chrome, the `<span>` and `::selection` has different height, which causes the orange `.ProseMirror-active-search-match` is slightly higher than the yellow `.ProseMirror-search-match`. I think this doesn't bother users. Just FYI.

**Before**


https://github.com/ProseMirror/prosemirror-search/assets/24715727/68614750-d7ad-4666-9d45-139f7ce78759

**After**


https://github.com/ProseMirror/prosemirror-search/assets/24715727/8a0cbc4e-e2b6-433a-86cd-838c7e38b1ec

