### PR TITLE
feat: SearchQuery.filterResult, an optional filter on results

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,10 @@
 import {EditorState} from "prosemirror-state"
 import {Node, Slice, Fragment} from "prosemirror-model"
 
+/// A filter to further select the search results
+/// (e.g. you may keep only the ones that have a certain Mark).
+export type SearchResultFilter = (state: EditorState, result: SearchResult) => boolean
+
 export class SearchQuery {
   /// The search string (or regular expression).
   readonly search: string
@@ -22,6 +26,8 @@ export class SearchQuery {
   /// When true, matches that contain words are ignored when there are
   /// further word characters around them.
   readonly wholeWord: boolean
+  /// A filter on results (e.g. on the Marks they have).
+  readonly filterResult: SearchResultFilter | null
 
   /// @internal
   impl: QueryImpl
@@ -42,6 +48,8 @@ export class SearchQuery {
     replace?: string,
     /// Enable whole-word matching.
     wholeWord?: boolean,
+    /// A filter on results (e.g. on the Marks they have).
+    filterResult?: SearchResultFilter,
   }) {
     this.search = config.search
     this.caseSensitive = !!config.caseSensitive
@@ -50,6 +58,7 @@ export class SearchQuery {
     this.replace = config.replace || ""
     this.valid = !!this.search && !(this.regexp && !validRegExp(this.search))
     this.wholeWord = !!config.wholeWord
+    this.filterResult = config.filterResult || null
     this.impl = !this.valid ? nullQuery : this.regexp ? new RegExpQuery(this) : new StringQuery(this)
   }
 
@@ -83,7 +92,10 @@ export class SearchQuery {
 
   /// @internal
   checkResult(state: EditorState, result: SearchResult) {
-    return this.wholeWord ? checkWordBoundary(state, result.from) && checkWordBoundary(state, result.to) : true
+    let ok = this.wholeWord ? checkWordBoundary(state, result.from) && checkWordBoundary(state, result.to) : true
+    if (!ok) return false
+    if (this.filterResult) ok = this.filterResult(state, result)
+    return ok
   }
 
   /// @internal

--- a/test/test-search.ts
+++ b/test/test-search.ts
@@ -3,9 +3,10 @@ import {Node} from "prosemirror-model"
 
 import {SearchQuery, search,
         findNext, findNextNoWrap, findPrev, findPrevNoWrap,
-        replaceNext, replaceNextNoWrap, replaceCurrent, replaceAll} from "prosemirror-search"
+        replaceNext, replaceNextNoWrap, replaceCurrent, replaceAll,
+        SearchResult} from "prosemirror-search"
 
-import {doc, blockquote, p, img, eq} from "prosemirror-test-builder"
+import {doc, blockquote, p, img, em, eq} from "prosemirror-test-builder"
 import ist from "ist"
 
 type Query = ConstructorParameters<typeof SearchQuery>[0] & {range?: {from: number, to: number}}
@@ -170,6 +171,17 @@ describe("search", () => {
                   p("one one one one one"),
                   p("one two two two one"),
                   replaceAll)
+    })
+  })
+
+  describe("filterResult", () => {
+    it("lets you replace only emphasized texts", () => {
+      const filterResult = (state: EditorState, result: SearchResult) =>
+        state.doc.rangeHasMark(result.from, result.to, state.schema.marks.em.create())
+      testCommand({search: "one", replace: "two", filterResult},
+        doc(p("this one"), p("that ", em("one")), blockquote(p("another ", em("one")))),
+        doc(p("this one"), p("that ", em("two")), blockquote(p("another ", em("two")))),
+        replaceAll)
     })
   })
 })


### PR DESCRIPTION
This should be a more conformant version of [this PR](https://github.com/ProseMirror/prosemirror-search/pull/4).

I added an optional filter on results, that work the same way of `checkWordBoundary`.

In particular I wanted to search for a text that also has some `Mark`s.

I changed the internal `checkResult` function -- originally intended only for the `wholeWord` option -- this way:

```ts
  checkResult(state: EditorState, result: SearchResult) {
    let ok = this.wholeWord ? checkWordBoundary(state, result.from) && checkWordBoundary(state, result.to) : true
    if (!ok) return false
    if (this.filterResult) ok = this.filterResult(state, result)
    return ok
  }
```

This are two filters that I use to check if the searched text has one or all the `Mark`s in a set:

```ts
const allMarksFilter: (marks: Mark[]) => SearchResultFilter = (marks) => (state, result) => {
  if (marks) {
    const { from, to } = result
    return marks.every(mark => state.doc.rangeHasMark(from, to, mark))
  }
  return true
}

const oneOfMarksFilter: (marks: Mark[]) => SearchResultFilter = (marks) => (state, result) => {
  if (marks) {
    const { from, to } = result
    return !!marks.find(mark => state.doc.rangeHasMark(from, to, mark))
  }
  return true
}
```

I've also added a test.