### PR TITLE
fix: Fix a bug in replacement in deeply-nested inline nodes with content

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -122,7 +122,7 @@ export class SearchQuery {
       } else if (groupSpan = groups[part.group]) {
         let level = $from.depth
         for (let l = level; l > 0; l--)
-        if ($from.node(l).isInline) level = l - 1
+          if ($from.node(l).isInline) level = l - 1
         let from = $from.start(level) + groupSpan[0], to = $from.start(level) + groupSpan[1]
         if (part.copy) { // Copied content
           frag = frag.append(state.doc.slice(from, to).content)

--- a/src/query.ts
+++ b/src/query.ts
@@ -121,7 +121,8 @@ export class SearchQuery {
         frag = frag.addToEnd(state.schema.text(part, marks))
       } else if (groupSpan = groups[part.group]) {
         let level = $from.depth
-        while (level > 0 && $from.node(level).isInline) level--
+        for (let l = level; l > 0; l--)
+        if ($from.node(l).isInline) level = l - 1
         let from = $from.start(level) + groupSpan[0], to = $from.start(level) + groupSpan[1]
         if (part.copy) { // Copied content
           frag = frag.append(state.doc.slice(from, to).content)

--- a/test/test-search.ts
+++ b/test/test-search.ts
@@ -144,11 +144,11 @@ describe("search", () => {
     })
   })
 
-  function footnoteSchema() {
+  function footnoteSchema(content?: string) {
     let footnoteSchema = new Schema({
       nodes: schema.spec.nodes.addBefore("image", "footnote", {
         group: "inline",
-        content: "text*",
+        content: content || "text*",
         inline: true,
         // This makes the view treat the node as a leaf, even though it
         // technically has content
@@ -200,6 +200,13 @@ describe("search", () => {
       testCommand({search: "“([^”]+)”", replace: "$1", regexp: true}, 
                   b.p("text", b.footnote("This is the <a>“footnote”<b> text")),
                   b.p("text", b.footnote("This is the <a>footnote<b> text")),
+                  replaceCurrent)
+    })
+    it("replaces delimiters with regexp inside deeply-nested non-leaf atoms", () => {
+      let b = footnoteSchema("block*")
+      testCommand({search: "“([^”]+)”", replace: "$1", regexp: true}, 
+                  b.p("text", b.footnote(b.p("This is the <a>“footnote”<b> text"))),
+                  b.p("text", b.footnote(b.p("This is the <a>footnote<b> text"))),
                   replaceCurrent)
     })
   })


### PR DESCRIPTION
It solves the bug described [here](https://github.com/ProseMirror/prosemirror-search/pull/6#issuecomment-2228124468), for replacements that happen in inline nodes whose content is made of non-inline nodes (e.g. a footnote that contains blocks, like `Note` in [Pandoc model](https://hackage.haskell.org/package/pandoc-types-1.23/docs/Text-Pandoc-Definition.html#t:Inline)).

The patch looks for the upper node that has no inline ancestors, and it searches backwards until depth 1:

```ts
  let level = $from.depth
  for (let l = level; l > 0; l--)
    if ($from.node(l).isInline) level = l - 1
```

(I realize I forgot indentation on the third line in my PR, you should fix it, sorry @marijnh )

Maybe this is more efficient (but I have not tested it):

```ts
  let level = $from.depth
  for (let l = 1; l <= $from.depth; l++)
    if ($from.node(l).isInline) { level = l - 1; break }
 ```